### PR TITLE
Refactor EconomyCraft configuration and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,46 @@
 
 EconomyCraft provides a simple cross-platform economy system for Fabric and NeoForge servers. The mod requires Architectury API and targets Minecraft 1.21.7 and newer.
 
+## Commands
+
+- `/balance [player]` – Check balances.
+- `/pay <player> <amount>` – Transfer money.
+- `/daily` – Claim a daily login bonus.
+- `/shop` – Opens the shop UI.
+- `/shop sell <price>` – Sell the item in your hand.
+- `/orders` – Opens the orders UI to browse and fulfill requests.
+- `/orders request <item> <amount> <price>` – Create an item request.
+- `/orders claim` – Claim items bought or requested while offline.
+- Admin: `/eco addmoney <player> <amount>`, `/eco setmoney <player> <amount>`, `/eco removeplayer <player>`, `/eco toggleScoreboard`.
+
+Non-admin commands such as `/pay` or `/daily` are standalone by default and also work under `/eco` (e.g., `/eco pay`). Set `standalone_commands` to `false` in `config.json` to require the `/eco` prefix. Admin commands use `/eco` unless `standalone_admin_commands` is enabled.
+
+Configuration and player data are stored in `config/economycraft/`. A balance sidebar shows the top players and can be toggled with `/eco toggleScoreboard`.
+
+## Configuration
+
+Example `config.json`:
+
+```json
+{
+  "startingBalance": 1000,
+  "dailyAmount": 100,
+  "taxRate": 0.1,
+  "standalone_commands": true,
+  "standalone_admin_commands": false
+}
+```
+
+- `startingBalance` – initial money for new players. Default: `1000`.
+- `dailyAmount` – money given by `/daily`. Default: `100`.
+- `taxRate` – percentage tax applied to trades and orders. Default: `0.1`.
+- `standalone_commands` – enable standalone `/pay`, `/daily`, etc. Default: `true`.
+- `standalone_admin_commands` – enable standalone `/addmoney`, `/setmoney`, etc. Default: `false`.
+
 ## Features
 
-- `/eco balance [player]` – Check balances.
-- `/eco pay <player> <amount>` – Transfer money.
-- `/eco addmoney <player> <amount>` – Admin command.
-- `/eco setmoney <player> <amount>` – Admin command.
-- `/eco removeplayer <player>` – Admin command to drop a player from the economy.
-- `/eco daily` – Claim a daily login bonus.
-Balances and configuration live in `config/EconomyCraft/` (`balances.json`, `daily.json`, `config.json`, etc.) and a live leaderboard is shown on the sidebar sorted by balance. Your rank appears below the top players.
+- Cross-platform economy for Fabric and NeoForge.
+- Shop and order request system.
+- Optional balance sidebar with top balances.
+- Server-side only.
 
-### Shop Commands
-- `/eco shop` – Opens the chest-based shop UI.
-- `/eco shop sell <price>` – Sell the item in your hand.
-
-### Orders Commands
-- `/eco orders` – Opens the orders UI to browse and fulfill requests.
-- `/eco orders request <item> <amount> <price>` – Create an item request.
-- `/eco orders claim` – Claim items bought or requested while offline.
-
-Server-side only.

--- a/README_MODRINTH.md
+++ b/README_MODRINTH.md
@@ -1,0 +1,42 @@
+# EconomyCraft
+
+EconomyCraft adds a lightweight, server-side economy system for Fabric and NeoForge.
+
+## Commands
+- `/balance [player]` – Check balances.
+- `/pay <player> <amount>` – Transfer money.
+- `/daily` – Claim a daily login bonus.
+- `/shop` – Open the player shop.
+- `/orders` – Browse and fulfill item orders.
+- Admin: `/eco addmoney <player> <amount>`, `/eco setmoney <player> <amount>`, `/eco removeplayer <player>`, `/eco toggleScoreboard`.
+
+Non-admin commands such as `/pay` or `/daily` are standalone by default and also work under `/eco`. Set `standalone_commands` to `false` in the config to require the `/eco` prefix. Admin commands use `/eco` unless `standalone_admin_commands` is enabled.
+
+## Configuration
+Configuration and data are stored at `config/economycraft/`.
+
+Example `config.json`:
+```json
+{
+  "startingBalance": 1000,
+  "dailyAmount": 100,
+  "taxRate": 0.1,
+  "standalone_commands": true,
+  "standalone_admin_commands": false
+}
+```
+
+- `startingBalance` – initial money for new players. Default: `1000`.
+- `dailyAmount` – money given by `/daily`. Default: `100`.
+- `taxRate` – percentage tax on trades and orders. Default: `0.1`.
+- `standalone_commands` – enable standalone `/pay`, `/daily`, etc. Default: `true`.
+- `standalone_admin_commands` – enable standalone `/addmoney`, `/setmoney`, etc. Default: `false`.
+
+## Features
+- Cross-platform economy for Fabric and NeoForge.
+- Shop and order request system.
+- Optional balance sidebar with top balances.
+- Daily rewards and player-to-player payments.
+
+Server-side only.
+

--- a/common/src/main/java/com/reazip/economycraft/EconomyConfig.java
+++ b/common/src/main/java/com/reazip/economycraft/EconomyConfig.java
@@ -1,6 +1,7 @@
 package com.reazip.economycraft;
 
 import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
 import net.minecraft.server.MinecraftServer;
 
 import java.io.IOException;
@@ -14,6 +15,10 @@ public class EconomyConfig {
     public long startingBalance = 1000;
     public long dailyAmount = 100;
     public double taxRate = 0.10; // 10%
+    @SerializedName("standalone_commands")
+    public boolean standaloneCommands = true;
+    @SerializedName("standalone_admin_commands")
+    public boolean standaloneAdminCommands = false;
 
     private static EconomyConfig INSTANCE = new EconomyConfig();
 
@@ -23,7 +28,7 @@ public class EconomyConfig {
 
     /** Loads the config from disk, creating it with defaults if necessary. */
     public static void load(MinecraftServer server) {
-        Path dir = server.getFile("config/EconomyCraft");
+        Path dir = server != null ? server.getFile("config/economycraft") : Path.of("config/economycraft");
         try { Files.createDirectories(dir); } catch (IOException ignored) {}
         Path file = dir.resolve("config.json");
         if (Files.exists(file)) {

--- a/common/src/main/java/com/reazip/economycraft/EconomyCraft.java
+++ b/common/src/main/java/com/reazip/economycraft/EconomyCraft.java
@@ -18,6 +18,7 @@ public final class EconomyCraft {
     private static final NumberFormat FORMAT = NumberFormat.getInstance(Locale.GERMANY);
 
     public static void init() {
+        EconomyConfig.load(null);
         CommandRegistrationEvent.EVENT.register((dispatcher, registry, selection) -> {
             EconomyCommands.register(dispatcher);
         });

--- a/common/src/main/java/com/reazip/economycraft/orders/OrderManager.java
+++ b/common/src/main/java/com/reazip/economycraft/orders/OrderManager.java
@@ -25,9 +25,10 @@ public class OrderManager {
 
     public OrderManager(MinecraftServer server) {
         this.server = server;
-        Path dir = server.getFile("config/EconomyCraft");
-        try { Files.createDirectories(dir); } catch (IOException ignored) {}
-        this.file = dir.resolve("orders.json");
+        Path dir = server.getFile("config/economycraft");
+        Path dataDir = dir.resolve("data");
+        try { Files.createDirectories(dataDir); } catch (IOException ignored) {}
+        this.file = dataDir.resolve("orders.json");
         load();
     }
 

--- a/common/src/main/java/com/reazip/economycraft/orders/OrdersUi.java
+++ b/common/src/main/java/com/reazip/economycraft/orders/OrdersUi.java
@@ -52,7 +52,7 @@ public final class OrdersUi {
     }
 
     private static class RequestMenu extends AbstractContainerMenu {
-        private final OrderManager market;
+        private final OrderManager orders;
         private final EconomyManager eco;
         private final ServerPlayer viewer;
         private List<OrderRequest> requests = new ArrayList<>();
@@ -60,13 +60,13 @@ public final class OrdersUi {
         private int page;
         private final Runnable listener = this::updatePage;
 
-        RequestMenu(int id, Inventory inv, OrderManager market, EconomyManager eco, ServerPlayer viewer) {
+        RequestMenu(int id, Inventory inv, OrderManager orders, EconomyManager eco, ServerPlayer viewer) {
             super(MenuType.GENERIC_9x6, id);
-            this.market = market;
+            this.orders = orders;
             this.eco = eco;
             this.viewer = viewer;
             updatePage();
-            market.addListener(listener);
+            orders.addListener(listener);
             for (int i = 0; i < 54; i++) {
                 int r = i / 9;
                 int c = i % 9;
@@ -87,7 +87,7 @@ public final class OrdersUi {
         }
 
         private void updatePage() {
-            requests = new ArrayList<>(market.getRequests());
+            requests = new ArrayList<>(orders.getRequests());
             container.clearContent();
             int start = page * 45;
             int totalPages = (int)Math.ceil(requests.size() / 45.0);
@@ -193,7 +193,7 @@ public final class OrdersUi {
         @Override
         public void removed(Player player) {
             super.removed(player);
-            market.removeListener(listener);
+            orders.removeListener(listener);
         }
 
         @Override public ItemStack quickMoveStack(Player player, int idx) { return ItemStack.EMPTY; }
@@ -246,7 +246,7 @@ public final class OrdersUi {
         public void clicked(int slot, int drag, ClickType type, Player player) {
             if (type == ClickType.PICKUP) {
                 if (slot == 2) {
-                    OrderRequest current = parent.market.getRequest(request.id);
+                    OrderRequest current = parent.orders.getRequest(request.id);
                     if (current == null) {
                         ((ServerPlayer) player).sendSystemMessage(Component.literal("Request no longer available").withStyle(ChatFormatting.RED));
                     } else if (!parent.hasItems((ServerPlayer) player, current.item, current.amount)) {
@@ -261,11 +261,11 @@ public final class OrdersUi {
                             long tax = Math.round(cost * EconomyConfig.get().taxRate);
                             parent.eco.setMoney(current.requester, bal - cost);
                             parent.eco.addMoney(player.getUUID(), cost - tax);
-                            parent.market.removeRequest(current.id);
+                            parent.orders.removeRequest(current.id);
                             int remaining = current.amount;
                             while (remaining > 0) {
                                 int c = Math.min(current.item.getMaxStackSize(), remaining);
-                                parent.market.addDelivery(current.requester, new ItemStack(current.item.getItem(), c));
+                                parent.orders.addDelivery(current.requester, new ItemStack(current.item.getItem(), c));
                                 remaining -= c;
                             }
                             ((ServerPlayer) player).sendSystemMessage(Component.literal("Fulfilled request for " + current.amount + "x " + current.item.getHoverName().getString() + " and earned " + EconomyCraft.formatMoney(cost - tax)).withStyle(ChatFormatting.GREEN));
@@ -345,7 +345,7 @@ public final class OrdersUi {
         public void clicked(int slot, int drag, ClickType type, Player player) {
             if (type == ClickType.PICKUP) {
                 if (slot == 2) {
-                    OrderRequest removed = parent.market.removeRequest(request.id);
+                    OrderRequest removed = parent.orders.removeRequest(request.id);
                     if (removed != null) {
                         ((ServerPlayer) player).sendSystemMessage(Component.literal("Request removed").withStyle(ChatFormatting.GREEN));
                     } else {

--- a/common/src/main/java/com/reazip/economycraft/shop/ShopManager.java
+++ b/common/src/main/java/com/reazip/economycraft/shop/ShopManager.java
@@ -25,9 +25,10 @@ public class ShopManager {
 
     public ShopManager(MinecraftServer server) {
         this.server = server;
-        Path dir = server.getFile("config/EconomyCraft");
-        try { Files.createDirectories(dir); } catch (IOException ignored) {}
-        this.file = dir.resolve("shop.json");
+        Path dir = server.getFile("config/economycraft");
+        Path dataDir = dir.resolve("data");
+        try { Files.createDirectories(dataDir); } catch (IOException ignored) {}
+        this.file = dataDir.resolve("shop.json");
         load();
     }
 


### PR DESCRIPTION
## Summary
- restructure config files under `config/economycraft` with separate data folder
- add config flags for optional standalone commands and new `/eco toggleScoreboard`
- replace legacy market references with orders and document on Modrinth/CurseForge
- document standalone command usage and detailed config options in READMEs
