### PR TITLE
Support Minecraft 1.21.x

### DIFF
--- a/common/src/main/java/com/reazip/economycraft/EconomyCraft.java
+++ b/common/src/main/java/com/reazip/economycraft/EconomyCraft.java
@@ -41,7 +41,7 @@ public final class EconomyCraft {
                         .append(Component.literal("[Claim]")
                                 .withStyle(s -> s.withUnderlined(true)
                                         .withColor(ChatFormatting.GREEN)
-                                        .withClickEvent(new ClickEvent.RunCommand("/eco orders claim"))));
+                                        .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/eco orders claim"))));
                 player.sendSystemMessage(msg);
             }
         });

--- a/common/src/main/java/com/reazip/economycraft/orders/OrderManager.java
+++ b/common/src/main/java/com/reazip/economycraft/orders/OrderManager.java
@@ -111,8 +111,8 @@ public class OrderManager {
                         } else {
                             String itemId = o.get("item").getAsString();
                             int count = o.get("count").getAsInt();
-                            var holder = BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemId));
-                            if (holder.isPresent()) stack = new ItemStack(holder.get().value(), count);
+                            var item = BuiltInRegistries.ITEM.getOptional(ResourceLocation.parse(itemId));
+                            if (item.isPresent()) stack = new ItemStack(item.get(), count);
                         }
                         if (!stack.isEmpty()) list.add(stack);
                     }

--- a/common/src/main/java/com/reazip/economycraft/orders/OrderRequest.java
+++ b/common/src/main/java/com/reazip/economycraft/orders/OrderRequest.java
@@ -42,7 +42,7 @@ public class OrderRequest {
         }
         if (r.item == null || r.item.isEmpty()) {
             String itemId = obj.get("item").getAsString();
-            BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemId)).ifPresent(h -> r.item = new ItemStack(h.value()));
+            BuiltInRegistries.ITEM.getOptional(ResourceLocation.parse(itemId)).ifPresent(i -> r.item = new ItemStack(i));
         }
         return r;
     }

--- a/common/src/main/java/com/reazip/economycraft/orders/OrdersUi.java
+++ b/common/src/main/java/com/reazip/economycraft/orders/OrdersUi.java
@@ -276,7 +276,7 @@ public final class OrdersUi {
                                         .append(Component.literal("[Claim]")
                                                 .withStyle(s -> s.withUnderlined(true)
                                                         .withColor(ChatFormatting.GREEN)
-                                                        .withClickEvent(new ClickEvent.RunCommand("/eco orders claim"))));
+                                                        .withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/eco orders claim"))));
                                 requesterPlayer.sendSystemMessage(msg);
                             }
                             parent.requests.removeIf(r -> r.id == current.id);

--- a/common/src/main/java/com/reazip/economycraft/shop/ShopListing.java
+++ b/common/src/main/java/com/reazip/economycraft/shop/ShopListing.java
@@ -42,7 +42,7 @@ public class ShopListing {
         if (l.item == null || l.item.isEmpty()) {
             String itemId = obj.get("item").getAsString();
             int count = obj.get("count").getAsInt();
-            BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemId)).ifPresent(h -> l.item = new ItemStack(h.value(), count));
+            BuiltInRegistries.ITEM.getOptional(ResourceLocation.parse(itemId)).ifPresent(i -> l.item = new ItemStack(i, count));
         }
         return l;
     }

--- a/common/src/main/java/com/reazip/economycraft/shop/ShopManager.java
+++ b/common/src/main/java/com/reazip/economycraft/shop/ShopManager.java
@@ -115,8 +115,8 @@ public class ShopManager {
                         } else {
                             String itemId = o.get("item").getAsString();
                             int count = o.get("count").getAsInt();
-                            var holder = BuiltInRegistries.ITEM.get(ResourceLocation.parse(itemId));
-                            if (holder.isPresent()) stack = new ItemStack(holder.get().value(), count);
+                            var item = BuiltInRegistries.ITEM.getOptional(ResourceLocation.parse(itemId));
+                            if (item.isPresent()) stack = new ItemStack(item.get(), count);
                         }
                         if (!stack.isEmpty()) list.add(stack);
                     }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -14,7 +14,7 @@
   "mixins": ["economycraft.mixins.json"],
   "depends": {
     "fabricloader": ">=0.16.4",
-    "minecraft": "~1.21.7",
+    "minecraft": "~1.21",
     "java": ">=21",
     "architectury": ">=17.0.6",
     "fabric-api": "*"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,10 +9,10 @@ archives_name = economycraft
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 1.21.7
+minecraft_version = 1.21
 
 # Dependencies
 architectury_api_version = 17.0.6
 fabric_loader_version = 0.16.4
-fabric_api_version = 0.129.0+1.21.7
-neoforge_version = 21.7.8-beta
+fabric_api_version = 0.102.0+1.21
+neoforge_version = 21.0.9-beta

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -14,14 +14,14 @@ Simple server-side economy and shop mod.
 [[dependencies.economycraft]]
 modId = "neoforge"
 type = "required"
-versionRange = "[21.7,)"
+versionRange = "[21,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.economycraft]]
 modId = "minecraft"
 type = "required"
-versionRange = "[1.21.7,)"
+versionRange = "[1.21,)"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
## Summary
- Broaden Minecraft compatibility to 1.21.x across Fabric and NeoForge.
- Use `getOptional` for registry lookups to match the 1.21 API.
- Replace `ClickEvent.RunCommand` with standard run-command constructor for older patches.

## Testing
- `./gradlew build`